### PR TITLE
Changed behavior to match what is in README.md

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,17 +1,39 @@
 const Meta = imports.gi.Meta;
 
+/* This has been tested with both static and dynamic workspaces.  It
+ * works better with dynamic workspaces, but can work well if you have
+ * enough static ones.
+ */
+
+/* Possible future options: (OO)
+ *  always move to last / find first empty / find last empty
+ *  target a specific desktop when none are empty
+ *  (don't) skip first desktop
+ */
 function check(act) {
   const win = act.meta_window;
+  const screen = win.get_screen();
   if (win.window_type !== Meta.WindowType.NORMAL)
     return;
   if (win.get_maximized() !== Meta.MaximizeFlags.BOTH)
     return;
-  win.get_workspace().list_windows()
-    .filter(w => w !== win)
-    .reduce((isFirst, w) => {
-      w.change_workspace_by_index(win.get_workspace().index() + 1, isFirst);
-      return false;
-    }, true);
+  w = win.get_workspace().list_windows()
+    .filter(w => w !== win && !w.is_always_on_all_workspaces());
+  if (w.length>= 1) {
+    // put on last workspace if all else fails (OO)
+    lastworkspace = screen.get_n_workspaces()-1
+    // always start with the second workspace (OO)
+    if (lastworkspace<1) lastworkspace=1
+    for (emptyworkspace=1 ; emptyworkspace<lastworkspace; emptyworkspace++){
+      wc = screen.get_workspace_by_index(emptyworkspace).list_windows().filter(w=>!w.is_always_on_all_workspaces()).length
+      if (wc<1	) break;
+    }
+    // don't try to move it if we're already here (break recursion)
+    if (emptyworkspace == win.get_workspace().index())
+      return;
+    win.change_workspace_by_index(emptyworkspace,1)
+    screen.get_workspace_by_index(emptyworkspace).activate(global.get_current_time())
+  }
 }
 
 const _handles = [];


### PR DESCRIPTION
Old behavior:
* When maximizing a window, push all other windows to the next desktop
* When switching to a desktop containing a maximized window, push all windows...

New behavior:
* When maximizing a window, move window to next empty desktop or last desktop
* When switching desktops to or from one containing a maximized window,
  move the window with focus to an empty desktop
* Never place a maximized window on the first desktop

Some of these behaviors could be optional.  (Discuss?  Make a options panel?)